### PR TITLE
AIAGENTPOC-2: We want to update the default values of starting players, from 10 players to 8.

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -15,7 +15,7 @@ const SettingsPage: React.FC = () => {
     const navigate = useNavigate();
 
     // State for the values, with some standard values
-    const [players, setPlayers] = useState(10);
+    const [players, setPlayers] = useState(8);
     const [buyIn, setBuyIn] = useState(500);
     const [totalPrizePool, setTotalPrizePool] = useState(5000); // Denna kommer att beräknas
     const [startStack, setStartStack] = useState(2500);


### PR DESCRIPTION
# We want to update the default values of starting players, from 10 players to 8.

## Description
When we start upp the application, it will have a predefined number of players, and it is set to 10 players. 
We want to change this to be 8 players instead. 

## Changes
The task requires changing the default number of players displayed when the application starts.  This value is currently initialized within the `SettingsPage` component.  Therefore, only this file needs to be modified. By changing the `useState` value for `players` from 10 to 8, the component will render with the desired default value. No new files are required, and the change is contained within the existing component's logic, maintaining a clean and organized structure.

## Related Issue
- AIAGENTPOC-2
