### PR TITLE
AIAGENTPOC-2: We want to update the default values of starting players, from 10 players to 8.

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -15,7 +15,7 @@ const SettingsPage: React.FC = () => {
     const navigate = useNavigate();
 
     // State for the values, with some standard values
-    const [players, setPlayers] = useState(10);
+    const [players, setPlayers] = useState(8);
     const [buyIn, setBuyIn] = useState(500);
     const [totalPrizePool, setTotalPrizePool] = useState(5000); // Denna kommer att beräknas
     const [startStack, setStartStack] = useState(2500);


### PR DESCRIPTION
# We want to update the default values of starting players, from 10 players to 8.

## Description
When we start upp the application, it will have a predefined number of players, and it is set to 10 players. 
We want to change this to be 8 players instead. 

## Changes
The task requires changing the default number of players displayed when the SettingsPage component initially renders. This can be achieved by simply modifying the `useState` hook for the `players` variable within the `SettingsPage.tsx` component.  No new files are necessary, and the change is localized to this single component. This is the most straightforward and efficient solution, maintaining the existing code structure and minimizing complexity.

## Related Issue
- AIAGENTPOC-2
