### PR TITLE
AIAGENTPOC-2: We want to update the default values of starting players, from 10 players to 8.

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -15,7 +15,7 @@ const SettingsPage: React.FC = () => {
     const navigate = useNavigate();
 
     // State for the values, with some standard values
-    const [players, setPlayers] = useState(10);
+    const [players, setPlayers] = useState(8);
     const [buyIn, setBuyIn] = useState(500);
     const [totalPrizePool, setTotalPrizePool] = useState(5000); // Denna kommer att beräknas
     const [startStack, setStartStack] = useState(2500);


### PR DESCRIPTION
# We want to update the default values of starting players, from 10 players to 8.

## Description
When we start upp the application, it will have a predefined number of players, and it is set to 10 players. 
We want to change this to be 8 players instead. 

## Changes
The task requires changing the default number of players displayed when the application starts. This value is currently managed by the `players` state within the `SettingsPage` component.  Therefore, the only modification needed is to change the initial value of this state within the `useState` hook. No new files need to be created, and no other modifications are necessary to achieve the desired behavior.

## Related Issue
- AIAGENTPOC-2
