### PR TITLE
AIAGENTPOC-2: We want to update the default values of starting players, from 10 players to 8.

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -15,7 +15,7 @@ const SettingsPage: React.FC = () => {
     const navigate = useNavigate();
 
     // State for the values, with some standard values
-    const [players, setPlayers] = useState(10);
+    const [players, setPlayers] = useState(8);
     const [buyIn, setBuyIn] = useState(500);
     const [totalPrizePool, setTotalPrizePool] = useState(5000); // Denna kommer att beräknas
     const [startStack, setStartStack] = useState(2500);


### PR DESCRIPTION
# We want to update the default values of starting players, from 10 players to 8.

## Description
When we start upp the application, it will have a predefined number of players, and it is set to 10 players. 
We want to change this to be 8 players instead. 

## Changes
The task requires changing the default number of players from 10 to 8. This value is currently managed within the `SettingsPage` component using the `useState` hook for the `players` variable.  Therefore, the only necessary modification is to change the initial value of this state within the `SettingsPage.tsx` file. No new files are needed, and no further changes in other parts of the application are required since this change is localized to the initial state of the `SettingsPage` component.  The calculation of the total prize pool and prize distribution are already dynamically handled based on the number of players, so these functions don't require modification.

## Related Issue
- AIAGENTPOC-2
