### PR TITLE
AIAGENTPOC-2: We want to update the default values of starting players, from 10 players to 8.

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -34,7 +34,7 @@ const SettingsPage: React.FC = () => {
     const navigate = useNavigate();
 
     // State for the values, with some standard values
-    const [players, setPlayers] = useState(10);
+    const [players, setPlayers] = useState(8);
     const [buyIn, setBuyIn] = useState(500);
     const [totalPrizePool, setTotalPrizePool] = useState(5000);
     const [startStack, setStartStack] = useState(2500);


### PR DESCRIPTION
# We want to update the default values of starting players, from 10 players to 8.

## Description
When we start upp the application, it will have a predefined number of players, and it is set to 10 players. 
We want to change this to be 8 players instead. 

## Changes
The task requires changing the default number of players displayed when the application starts.  This value is currently initialized within the `SettingsPage` component as the initial state of the `players` variable.  By changing this initial state value, the desired behavior will be achieved. No new files are needed, and the change is contained within a single, logical location.

## Related Issue
- AIAGENTPOC-2
