### PR TITLE
AIAGENTPOC-2: We want to update the default values of starting players, from 10 players to 8.

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -37,7 +37,7 @@ const SettingsPage: React.FC = () => {
     const location = useLocation();
 
     // State for the values, with some standard values
-    const [players, setPlayers] = useState(10);
+    const [players, setPlayers] = useState(8);
     const [buyIn, setBuyIn] = useState(500);
     const [totalPrizePool, setTotalPrizePool] = useState(5000);
     const [startStack, setStartStack] = useState(2500);
@@ -224,7 +224,7 @@ const SettingsPage: React.FC = () => {
         localStorage.removeItem('timerState');
         
         // Reset all state to default values
-        setPlayers(10);
+        setPlayers(8);
         setBuyIn(500);
         setTotalPrizePool(5000);
         setStartStack(2500);


### PR DESCRIPTION
# We want to update the default values of starting players, from 10 players to 8.

## Description
When we start upp the application, it will have a predefined number of players, and it is set to 10 players. 
We want to change this to be 8 players instead. 

## Changes
The task requires changing the default number of players displayed when the application starts.  This value is currently initialized within the `SettingsPage` component.  By changing the `useState` hook for the `players` variable, the initial value will be updated, and this will reflect in the UI on initial load.  No new files are needed, and the change is contained within a single component, maintaining a clean and focused modification.

## Related Issue
- AIAGENTPOC-2
